### PR TITLE
Fix ODR violation causing crash on disconnect

### DIFF
--- a/src/build_number.h
+++ b/src/build_number.h
@@ -1,2 +1,2 @@
 #pragma once
-#define NINJAM_BUILD_NUMBER 67
+#define NINJAM_BUILD_NUMBER 80

--- a/src/ui/ui_state.h
+++ b/src/ui/ui_state.h
@@ -6,7 +6,7 @@
 #include <vector>
 #include "ui/server_list_types.h"
 
-struct RemoteChannel {
+struct UiRemoteChannel {
     std::string name;
     int channel_index = -1;
     bool subscribed = true;
@@ -18,11 +18,11 @@ struct RemoteChannel {
     float vu_right = 0.0f;
 };
 
-struct RemoteUser {
+struct UiRemoteUser {
     std::string name;
     std::string address;
     bool mute = false;
-    std::vector<RemoteChannel> channels;
+    std::vector<UiRemoteChannel> channels;
 };
 
 struct UiState {
@@ -58,7 +58,7 @@ struct UiState {
     float master_vu_right = 0.0f;
 
     // Remote users
-    std::vector<RemoteUser> remote_users;
+    std::vector<UiRemoteUser> remote_users;
     bool users_dirty = false;
 
     // License dialog


### PR DESCRIPTION
Renamed UI types to avoid One Definition Rule violation:
- RemoteUser -> UiRemoteUser
- RemoteChannel -> UiRemoteChannel

Previously, both src/core/njclient.cpp and src/ui/ui_state.h defined classes named RemoteUser. This caused undefined behavior where the linker would bind the wrong destructor when deleting core RemoteUser objects, leading to crashes during disconnect as the UI destructor tried to access std::string/std::vector members at memory locations where the core object had WDL_String and fixed arrays.

The fix ensures unique symbol names for UI and core types, allowing the linker to correctly bind each destructor to its proper class.