### PR TITLE
Fix: Auto-initialize local channel on connection

### DIFF
--- a/src/build_number.h
+++ b/src/build_number.h
@@ -1,2 +1,2 @@
 #pragma once
-#define NINJAM_BUILD_NUMBER 80
+#define NINJAM_BUILD_NUMBER 82

--- a/src/threading/run_thread.cpp
+++ b/src/threading/run_thread.cpp
@@ -248,6 +248,17 @@ void run_thread_func(std::shared_ptr<NinjamPlugin> plugin) {
                 error_msg = err;
                 NLOG("[RunThread] Error: %s\n", err);
             }
+            
+            // Initialize default local channel when connection succeeds
+            if (current_status == NJClient::NJC_STATUS_OK) {
+                NLOG("[RunThread] Connection established, initializing local channel 0\n");
+                std::lock_guard<std::mutex> state_lock(plugin->state_mutex);
+                const char* ch_name = plugin->ui_state.local_name_input[0] ? 
+                                     plugin->ui_state.local_name_input : "Channel";
+                // Set default channel: stereo input (ch 0), 128kbps, transmit enabled
+                client->SetLocalChannelInfo(0, ch_name, true, 0|(1<<10), true, 128, true, true);
+                NLOG("[RunThread] Local channel 0 configured: name='%s'\n", ch_name);
+            }
         }
 
         if (current_status == NJClient::NJC_STATUS_OK) {


### PR DESCRIPTION
When connecting to a NINJAM server, the plugin now automatically creates and configures a default local channel (channel 0) with:
- Stereo input (both left and right channels)
- 128 kbps bitrate
- Transmission enabled

This fixes the issue where audio was only being monitored locally but not transmitted to the server because no local channels were configured.

Previously, users would connect successfully but couldn't transmit or receive audio until manually adjusting local channel settings in the UI. The plugin now behaves like other NINJAM clients by auto-initializing transmission on connection.