### PR TITLE
round BPM values to prevent float truncation mismatch (Fixes #15)

### DIFF
--- a/juce/NinjamRunThread.cpp
+++ b/juce/NinjamRunThread.cpp
@@ -477,15 +477,15 @@ void NinjamRunThread::detectBpmBpiChanges(NJClient* client)
     }
 
     // Detect BPM change
-    if (prevBpm > 0.0f && static_cast<int>(prevBpm) != static_cast<int>(newBpm))
+    if (prevBpm > 0.0f && static_cast<int>(std::round(prevBpm)) != static_cast<int>(std::round(newBpm)))
     {
         processor.evt_queue.try_push(jamwide::BpmChangedEvent{prevBpm, newBpm});
 
         ChatMessage msg;
         msg.type = ChatMessageType::System;
         msg.content = "[Server] BPM changed from "
-                      + std::to_string(static_cast<int>(prevBpm))
-                      + " to " + std::to_string(static_cast<int>(newBpm));
+                      + std::to_string(static_cast<int>(std::round(prevBpm)))
+                      + " to " + std::to_string(static_cast<int>(std::round(newBpm)));
         msg.timestamp = currentTimeString();
         processor.chat_queue.try_push(std::move(msg));
 

--- a/juce/ui/BeatBar.cpp
+++ b/juce/ui/BeatBar.cpp
@@ -58,7 +58,7 @@ void BeatBar::paint(juce::Graphics& g)
         auto bpmArea = labelArea.removeFromLeft(36);
         g.setColour(textCol);
         g.setFont(numberFont);
-        g.drawText(juce::String(static_cast<int>(currentBpm_)), bpmArea,
+        g.drawText(juce::String(static_cast<int>(std::round(currentBpm_))), bpmArea,
                    juce::Justification::centredRight, false);
 
         // Separator "/"
@@ -158,7 +158,7 @@ void BeatBar::mouseDown(const juce::MouseEvent& e)
 void BeatBar::createVoteEditor(bool forBpm)
 {
     editingBpm_ = forBpm;
-    int currentVal = forBpm ? static_cast<int>(currentBpm_) : bpi_;
+    int currentVal = forBpm ? static_cast<int>(std::round(currentBpm_)) : bpi_;
 
     // Create TextEditor overlay
     voteEditor_ = std::make_unique<juce::TextEditor>();
@@ -188,7 +188,7 @@ void BeatBar::createVoteEditor(bool forBpm)
 
         if (valid && processorRef_)
         {
-            int existingVal = editingBpm_ ? static_cast<int>(currentBpm_) : bpi_;
+            int existingVal = editingBpm_ ? static_cast<int>(std::round(currentBpm_)) : bpi_;
             if (newVal != existingVal)
             {
                 jamwide::SendChatCommand cmd;

--- a/juce/ui/ConnectionBar.cpp
+++ b/juce/ui/ConnectionBar.cpp
@@ -603,12 +603,12 @@ void ConnectionBar::handleSyncClick()
             return;
         }
 
-        if (static_cast<int>(hostBpm) != static_cast<int>(serverBpm))
+        if (static_cast<int>(std::round(hostBpm)) != static_cast<int>(std::round(serverBpm)))
         {
             // BPM mismatch -- show bubble per UI-SPEC
-            juce::String msg = "Host tempo (" + juce::String(static_cast<int>(hostBpm))
+            juce::String msg = "Host tempo (" + juce::String(static_cast<int>(std::round(hostBpm)))
                 + " BPM) does not match server ("
-                + juce::String(static_cast<int>(serverBpm)) + " BPM)";
+                + juce::String(static_cast<int>(std::round(serverBpm))) + " BPM)";
             syncMismatchBubble = std::make_unique<juce::BubbleMessageComponent>(3000);
             addChildComponent(syncMismatchBubble.get());  // MUST come before showAt (review fix)
             syncMismatchBubble->showAt(&syncButton,

--- a/src/build_number.h
+++ b/src/build_number.h
@@ -1,2 +1,2 @@
 #pragma once
-#define JAMWIDE_BUILD_NUMBER 316
+#define JAMWIDE_BUILD_NUMBER 317


### PR DESCRIPTION
## Issue
On Windows (e.g. Bitwig 4), setting DAW tempo to N BPM caused sync to fail, reporting DAW tempo as N-1 due to float imprecision (e.g. `119.999` truncated to `119`).

## Fix
Wrapped float BPMs with `std::round()` before converting to `int` in `ConnectionBar`, `BeatBar`, and `NinjamRunThread`.

## Verification
Verified that host BPM matching now works correctly on Windows without tempo drift.